### PR TITLE
Add bulk repo permission removal script

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,12 +147,32 @@ Remove all write permissions from the ACL of the repository "MyRepo" in project 
   The name of the Azure DevOps project where the git repository is located.
 * RepoName (mandatory)  
   The name of the Azure DevOps git repository where the permissions should be changed.
-* Confirm (optional)  
+* Confirm (optional)
   If this is set, the script won't ask the user for confirmation before changing the permissions.
 
 ### PAT Permissions
 
 * Azure DevOps PAT token permissions: __Code: read__, __Identity: read__ and __Security: manage__
+
+
+## Remove-AdoGitRepoWritePermissionsAll
+
+Removes all write permissions from every repository in all projects of an organisation.
+
+### Usage
+
+Remove write permissions on all repositories in organisation "myorganisation".
+
+```powershell
+.\Remove-AdoGitRepoWritePermissionsAll.ps1 -OrgName "myorganisation"
+```
+
+### Parameters
+
+* OrgName (mandatory)
+  The name of the Azure DevOps organisation to use.
+* Confirm (optional)
+  If this is set, the script won't ask the user for confirmation before changing the permissions.
 
 
 ## Get-AdoVariableGroups

--- a/Source/AzureDevOpsTools.psd1
+++ b/Source/AzureDevOpsTools.psd1
@@ -68,6 +68,7 @@
         'Get-AdoVariableGroups',
         'Get-PipelineTransition',
         'Remove-AdoGitRepoWritePermissions',
+        'Remove-AdoGitRepoWritePermissionsAll',
         'Update-AdoVariables'
     )
 

--- a/Source/AzureDevOpsTools.psm1
+++ b/Source/AzureDevOpsTools.psm1
@@ -93,6 +93,21 @@ function Remove-AdoGitRepoWritePermissions
     & "$PSScriptRoot\Remove-AdoGitRepoWritePermissions.ps1" @PSBoundParameters
 }
 
+function Remove-AdoGitRepoWritePermissionsAll
+{
+    param (
+        [Parameter(Mandatory)]
+        [string]
+        $OrgName,
+
+        [Parameter()]
+        [switch]
+        $Confirm
+    )
+
+    & "$PSScriptRoot\Remove-AdoGitRepoWritePermissionsAll.ps1" @PSBoundParameters
+}
+
 function Update-AdoVariables
 {
     param (
@@ -133,4 +148,5 @@ Export-ModuleMember -Function Get-AdoPoolJobs
 Export-ModuleMember -Function Get-AdoPoolAgents
 Export-ModuleMember -Function Get-AdoVariableGroups
 Export-ModuleMember -Function Remove-AdoGitRepoWritePermissions
+Export-ModuleMember -Function Remove-AdoGitRepoWritePermissionsAll
 Export-ModuleMember -Function Update-AdoVariables

--- a/Source/Remove-AdoGitRepoWritePermissionsAll.ps1
+++ b/Source/Remove-AdoGitRepoWritePermissionsAll.ps1
@@ -1,0 +1,29 @@
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory)]
+    [string]
+    $OrgName,
+
+    [Parameter()]
+    [switch]
+    $Confirm
+)
+
+# Begin of main script
+$repos = & "$PSScriptRoot\Get-AdoGitRepos.ps1" -OrgName $OrgName -ExcludePermissions
+if ($null -eq $repos)
+{
+    Write-Error "No repositories found for org $OrgName"
+    exit 1
+}
+
+foreach ($repo in $repos)
+{
+    Write-Host "Processing project: $($repo.ProjectName), repo: $($repo.Name)"
+    $params = @{ OrgName = $OrgName; ProjectName = $repo.ProjectName; RepoName = $repo.Name }
+    if ($Confirm.IsPresent)
+    {
+        $params.Confirm = $true
+    }
+    & "$PSScriptRoot\Remove-AdoGitRepoWritePermissions.ps1" @params
+}


### PR DESCRIPTION
## Summary
- add Remove-AdoGitRepoWritePermissionsAll.ps1 to iterate all projects and repos
- wire new command into module and manifest
- document bulk removal script in README

## Testing
- `pwsh -NoLogo -NoProfile -Command "Get-Command ./Source/Remove-AdoGitRepoWritePermissionsAll.ps1"`
- `pwsh -NoLogo -NoProfile -Command ""`

------
https://chatgpt.com/codex/tasks/task_b_686d7b11d904833393b517c369e1f14a